### PR TITLE
Add node.js specific export that includes LocalFile, otherwise, refer to browser bundle that omits LocalFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": {
-      "import": "./esm/index.js"
-    },
-    "require": {
-      "require": "./dist/index.js"
+    ".": {
+      "import": "./esm/index.js",
+      "node": "./dist/index.js",
+      "browser": "./esm/browser.js",
+      "require": "./dist/browser.js"
     }
   },
   "repository": "GMOD/generic-filehandle2",
@@ -65,7 +65,7 @@
     "access": "public"
   },
   "browser": {
-    "./dist/localFile.js": false,
-    "./esm/localFile.js": false
+    "fs/promises": false,
+    "fs": false
   }
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,6 @@
+export * from './filehandle.ts'
+
+export { default as BlobFile } from './blobFile.ts'
+export { default as RemoteFile } from './remoteFile.ts'
+
+export { type GenericFilehandle } from './filehandle.ts'


### PR DESCRIPTION
v2.0.10  was converted to use package.json exports which made it allowed to be used in 'pure-ESM' contexts (but still it is a dual CJS/ESM package)

Unfortunately, this broke usage in next.js without special config, because next.js would try to import the node.js 'fs' module into a browser bundle

it would produce errors like this

```
Module not found: Can't resolve 'fs/promises'

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
../../src/gmod/generic-filehandle2/dist/index.cjs
./node_modules/@jbrowse/core/util/io/index.js
./node_modules/@jbrowse/plugin-trix/esm/TrixTextSearchAdapter/TrixTextSearchAdapter.js
./node_modules/@jbrowse/plugin-trix/esm/index.js
./node_modules/@jbrowse/react-linear-genome-view2/esm/corePlugins.js
./app/rpcWorker.ts

```

vite would also, but it would successfully ignore it by default

This PR fixes next.js usage without special config

It uses the following exports logic:

```
      "import": "./esm/index.js", // <-- general ESM imports: the full package
      "node": {
        "import": "./esm/index.js", // <-- node.js ESM import: the full package
        "require": "./dist/index.js" // <-- node.js CJS import: the full package
      },
      "browser": "./esm/browser.js", // <-- browser import like ESM: no LocalFile
      "require": "./dist/browser.js" // <-- other usages with CJS require: no LocalFile
```


this is a somewhat complex system, and even could be considered error prone, but it is a workaround for the "browser":{"dist/localFile.js":false} type declaration not working in ESM contexts