### PR TITLE
Update package.json to use browser field to avoid LocalFile import

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,20 @@
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": {
-      "import": "./esm/index.js"
+    ".": {
+      "import": {
+        "browser": "./esm/index.js",
+        "default": "./esm/index.js"
+      },
+      "require": {
+        "browser": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
     },
-    "require": {
-      "require": "./dist/index.js"
+    "./localFile": {
+      "browser": null,
+      "import": "./esm/localFile.js",
+      "require": "./dist/localFile.js"
     }
   },
   "repository": "GMOD/generic-filehandle2",
@@ -63,9 +72,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "browser": {
-    "./dist/localFile.js": false,
-    "./esm/localFile.js": false
   }
 }


### PR DESCRIPTION
## Background

In recent releases, we have tried to add "ESM" compatibility. It is a bit challenging, but ultimately more compatible and standardized in the ecosystem,

The "browser" field of package.json isn't used in ESM, which was causing "fs" to get imported


## This PR 

Incorporates the "browser" field into the "exports" field of package.json, which is what ESM package imports/exports use.

## Approach

I asked claude AI, with the package.json file as context

here is the chat log

It runs some 'agentic' steps in the 'thought bubbles', making changes on its own

### Chat log

- Datetime: 2025-06-10 12:14:59

- Model: claude/claude-3-7-sonnet-20250219

- Selected files:
  - package.json

> can you please convert the "browser" field in this package.json to use the "exports" or "imports" notation from modern ESM package.json


I'll help you convert the "browser" field in package.json to use the modern "exports" notation. Let me first examine the current package.json:

```
╭─  view  succeeded
│   running tool
│   path: package.json
╰─  tool finished
```


Now, I'll update the package.json to convert the "browser" field to use the modern "exports" notation. The current package.json already has an "exports" field, but it needs to be updated to include browser-specific conditions.

```
╭─  replace_in_file  failed
│   running tool
│   path: package.json
│   Error: Failed to find the old string:
│     "exports": {
│       "import": {
│         "browser": "./esm/index.js",
│         "default": "./esm/index.js"
│       },
│       "require": {
│         "browser": "./dist/index.js",
│         "default": "./dist/index.js"
│       },
│       "./localFile": {
│         "browser": null,
│         "import": "./esm/localFile.js",
│         "require": "./dist/localFile.js"
│       }
╰─    },
```

I apologize for the error. Let me check the current exports field in the package.json and make the correct update:

```
╭─  replace_in_file  succeeded
│   running tool
│   path: package.json
╰─  tool finished
```

Now, let's complete the conversion by removing the old "browser" field since we've incorporated its functionality into the "exports" field:

```
╭─  replace_in_file  succeeded
│   running tool
│   path: package.json
╰─  tool finished
```

Great! The package.json has been successfully updated. Let's complete this task.


✓  Task Completed
I've successfully converted the "browser" field in package.json to use the modern "exports" notation. Here's a summary of the changes:

1. Removed the legacy "browser" field:
```json
"browser": {
  "./dist/localFile.js": false,
  "./esm/localFile.js": false
}
```

2. Restructured the "exports" field to use the modern conditional exports format:
```json
"exports": {
  ".": {
    "import": {
      "browser": "./esm/index.js",
      "default": "./esm/index.js"
    },
    "require": {
      "browser": "./dist/index.js",
      "default": "./dist/index.js"
    }
  },
  "./localFile": {
    "browser": null,
    "import": "./esm/localFile.js",
    "require": "./dist/localFile.js"
  }
}
```

Key improvements in this update:

1. Added the root "." export condition to properly specify the main entry point
2. Used nested conditions for both module format ("import"/"require") and environment ("browser"/"default")
3. Set "./localFile" to resolve to `null` in browser environments, which achieves the same effect as the previous "browser" field setting it to `false`
4. Maintained separate paths for ESM and CommonJS formats

This modern exports configuration is more explicit and follows the Node.js and bundler best practices for package resolution. It will ensure that:

1. When imported in a browser, localFile.js will resolve to null
2. When imported in Node.js, localFile.js will resolve to the appropriate module format
3. The main package entry point will resolve correctly in all environments
