### PR TITLE
Add browser-specific bundle that excludes localFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,19 +6,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "browser": "./esm/index.js",
-        "default": "./esm/index.js"
+      "browser": {
+        "import": "./esm/browser.js",
+        "require": "./dist/browser.js"
       },
-      "require": {
-        "browser": "./dist/index.js",
-        "default": "./dist/index.js"
-      }
-    },
-    "./localFile": {
-      "browser": null,
-      "import": "./esm/localFile.js",
-      "require": "./dist/localFile.js"
+      "import": "./esm/index.js",
+      "require": "./dist/index.js"
     }
   },
   "repository": "GMOD/generic-filehandle2",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,19 @@
+// Browser-specific exports that exclude Node.js-only modules
+export * from './filehandle.ts'
+
+export { default as BlobFile } from './blobFile.ts'
+export { default as RemoteFile } from './remoteFile.ts'
+
+export class LocalFile {
+  readFile() {
+    throw new Error('unimplemented')
+  }
+  read() {
+    throw new Error('unimplemented')
+  }
+  close() {
+    throw new Error('unimplemented')
+  }
+}
+
+export { type GenericFilehandle } from './filehandle.ts'


### PR DESCRIPTION
This is yet another PR in attempting better ESM support. I am hoping to bring it to a close

This PR adds a browser specific build that excludes the LocalFile class

This actually requires jbrowse-components to mock the LocalFile, because it uses the browser-specific bundle in jest, but also uses LocalFile in jest as part of various "fetch mocks"

